### PR TITLE
Feat/add issue templates

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Bug Report
-title: '[Bug Report] '
+title: '[🐞Bug Report] '
 labels: 'bug'
 ---
 

--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug Report
+about: Bug Report
+title: '[Bug Report] '
+labels: 'bug'
+---
+
+# Overview
+
+*Here comes the overview of the bugs*
+
+*ここにbugの概要が入る*
+
+# Reproduction procedure
+
+*Describe in detail the steps to reproduce the bug*
+
+*バグの再現手順を詳細に記述する*
+
+# Scope of Impact
+
+*Where does this bug affect? How does this bug cause problems?*
+
+*このバグはどこに影響を与えるか？このバグがあるとどう困るのか？*
+
+# Cause
+
+*If you have identified the cause of this bug, write it here.*
+
+*バグの原因が特定できているならここに書く．*
+
+# Proposed Amendment
+
+*If you have a suggestion on how to fix it, write it here.*
+
+*修正案があればここに書く．*
+
+# Due date
+
+*Specify when this issue will be addressed.*
+
+*いつまでにこのissueに対応するのか，具体的に書く．*
+
+# Tasks
+
+*List tasks if they are broken down.*
+
+*タスク分解できているならリストアップする*
+
+- [ ] xxx

--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -35,12 +35,6 @@ labels: 'bug'
 
 *修正案があればここに書く．*
 
-# Due date
-
-*Specify when this issue will be addressed.*
-
-*いつまでにこのissueに対応するのか，具体的に書く．*
-
 # Tasks
 
 *List tasks if they are broken down.*

--- a/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/feature_request.md
@@ -23,12 +23,6 @@ labels: 'enhancement'
 
 *どこにどういうコードを記述するのか，具体的に書く．設計がある場合はここに書くか資料へのリンクを貼る．*
 
-# Due date
-
-*Specify when this issue will be addressed.*
-
-*いつまでにこのissueに対応するのか，具体的に書く．*
-
 # Tasks
 
 *List tasks if they are broken down.*

--- a/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Feature Request
-title: '[Feature Request] '
+title: '[🌟Feature Request] '
 labels: 'enhancement'
 ---
 

--- a/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: Feature Request
+about: Feature Request
+title: '[Feature Request] '
+labels: 'enhancement'
+---
+
+# Overview
+
+*Here comes the overview of the feature request*
+
+*ここにfeature requestの概要が入る*
+
+# Purpose
+
+*What is the feature request for?　Why is the feature needed?*
+
+*何のためのfeature requestか，なぜそのfeatureが必要なのか？*
+
+# Proposal
+
+*Specify where and what kind of code is to be written. If there is a design, write it here or provide a link to the document.*
+
+*どこにどういうコードを記述するのか，具体的に書く．設計がある場合はここに書くか資料へのリンクを貼る．*
+
+# Due date
+
+*Specify when this issue will be addressed.*
+
+*いつまでにこのissueに対応するのか，具体的に書く．*
+
+# Tasks
+
+*List tasks if they are broken down.*
+
+*タスク分解できているならリストアップする*
+
+- [ ] xxx

--- a/ISSUE_TEMPLATE/refactoring.md
+++ b/ISSUE_TEMPLATE/refactoring.md
@@ -1,35 +1,32 @@
 ---
 name: Refactoring
 about: Refactoring
-title: '[♻️Refactoring] '
-labels: 'refactor'
+title: "[♻️Refactoring] "
+labels: "refactor"
 ---
 
 # Overview
 
-*Here comes the overview of the refactoring*
+_Here comes the overview of the refactoring_
 
-*ここにrefactoringの概要が入る*
+_ここに refactoring の概要が入る_
 
 # Purpose
 
-*What is the refactoring for?　What makes us happy about that refactoring?*
+_What is the refactoring for?　 What makes us happy about that refactoring?_
 
-*何のためのrefactoringか，refactoringされると何が嬉しいのか*
+_何のための refactoring か，refactoring されると何が嬉しいのか_
 
 # Proposal
-*Describe the specifics of the refactoring*
 
-*リファクタリングの具体的な内容を書く*
+_Describe the specifics of the refactoring_
 
-# Due date
-*Specify when this issue will be addressed.*
-
-*いつまでにこのissueに対応するのか，具体的に書く．*
+_リファクタリングの具体的な内容を書く_
 
 # Tasks
-*List tasks if they are broken down.*
 
-*タスク分解できているならリストアップする*
+_List tasks if they are broken down._
+
+_タスク分解できているならリストアップする_
 
 - [ ] xxx

--- a/ISSUE_TEMPLATE/refactoring.md
+++ b/ISSUE_TEMPLATE/refactoring.md
@@ -1,7 +1,7 @@
 ---
 name: Refactoring
 about: Refactoring
-title: '[Refactoring] '
+title: '[♻️Refactoring] '
 labels: 'refactor'
 ---
 

--- a/ISSUE_TEMPLATE/refactoring.md
+++ b/ISSUE_TEMPLATE/refactoring.md
@@ -1,0 +1,35 @@
+---
+name: Refactoring
+about: Refactoring
+title: '[Refactoring] '
+labels: 'refactor'
+---
+
+# Overview
+
+*Here comes the overview of the refactoring*
+
+*ここにrefactoringの概要が入る*
+
+# Purpose
+
+*What is the refactoring for?　What makes us happy about that refactoring?*
+
+*何のためのrefactoringか，refactoringされると何が嬉しいのか*
+
+# Proposal
+*Describe the specifics of the refactoring*
+
+*リファクタリングの具体的な内容を書く*
+
+# Due date
+*Specify when this issue will be addressed.*
+
+*いつまでにこのissueに対応するのか，具体的に書く．*
+
+# Tasks
+*List tasks if they are broken down.*
+
+*タスク分解できているならリストアップする*
+
+- [ ] xxx

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,20 @@
 ## Scope of PR
+
 - *Here comes what the reviewee would like the reviewer to focus on.*
 - ...
 
 ## Major changes in codes/documents
+
 - *Here comes list of major changes.*
 - ...
 
 ## How to run the code
-*The reviewer might need some specific data that I should prepare for her/him, etc. 
+
+*The reviewer might need some specific data that I should prepare for her/him, etc.
 Add instruction here. ("See `README`" can be OK in some cases)*
 
-
 ## What to be reviewed
+
 - [ ] Is the code reproducible?
   - [ ] Can you reproduce the result with the instructions in `README.md`?
     - [ ] Does it have a link to the necessary files (training data/trained model)?
@@ -30,37 +33,5 @@ Add instruction here. ("See `README`" can be OK in some cases)*
 - [ ] Is coverage rate high enough? (if there is unittest)
 
 ## Requested deadline for review
+
 Can you please review this PR by `YYYY/MM/DD` ?
-
----
-## PRのscope
-- *ここにreviewerに注目して欲しい、PRの主眼が入る*
-- ...
-
-## code/documentsの主な変更点
-- *ここに主な変更点のリストが入る*
-- ...
-
-## コードの動かし方
-*動かすためのデータなどが必要な場合は、取得方法などを明示してください。("`README`を見ろ"というのでもOKな場合はあると思います)*
-
-## レビューすべき点
-- [ ] 結果は再現可能か?
-  - [ ] `README.md`のインストラクションに従って結果を再現できるか?
-    - [ ] 必要なファイル（学習用データ/学習済モデルなど）へのリンクはあるか?
-    - [ ] 仮想環境 (`poetry`/`docker`など)の構築ができるようになっているか?
-    - [ ] 全てのdependencyのversionは固定されているか？(`requirements.txt`ではよくこういう問題が起こる)
-- [ ] docstring/type annotationはされているか?
-  - [ ] 全てのmethod/classにdocstringはあるか？
-  - [ ] docstringは適切なformatで書かれているか？(`mkdocs/sphinx`で使用可能なもの)
-  - [ ] 全てのmethodにtype annotationはあるか?
-- [ ] コードは理解可能か?
-  - [ ] コードは理解可能/明快か?
-  - [ ] 実装された論理は正しい/意図された通りか?
-- [ ] 変数/method/classの名前は適切か?
-  - [ ] 変数/method/classの名前は意味があるものになっているか？(これらの名前は短いコメント文としての役割を持つので）
-  - [ ] 名前は[pep8](https://realpython.com/python-pep8/#naming-conventions)に従っているか?
-- [ ] coverage rateは十分高いか? (unittestがある場合)
-
-## 希望するreviewの締切
-このPRを`YYYY/MM/DD`までにreviewしてもらえますか?


### PR DESCRIPTION
## Scope of PR
- Add issue templates
- Edit PR template to more simplified version.
- cf. https://www.notion.so/arithmer/PR-Issue-template-f5cae8ae45484eaeae20c95e000f901a

## Major changes in codes/documents
- Added three types of issue templates: Feature Requests, Refactoring and Bug Report.
- Edited PR template: the Japanese version is removed for simplification.


## What to be reviewed
- [ ] Is the code reproducible?
  - [ ] Can you reproduce the result with the instructions in `README.md`?
    - [ ] Does it have a link to the necessary files (training data/trained model)?
    - [ ] Is a virtual environment (such as`poetry`/`docker`) set up?
    - [ ] Is the version of all the dependencies specified? (`requirements.txt` often has this issue)
- [ ] Does the code have docstring/type annotation?
  - [ ] Are there docstring in all the methods/class?
  - [ ] Are the docstring written in appropriate format (which can be used by `mkdocs/sphinx`)?
  - [ ] Are all the methods type annotated?
- [ ] Is the code comprehensive?
  - [ ] Is the code comprehensive/clear?
  - [ ] Is the logic correct/as intended?
- [ ] Are the names for variable/method/class appropriate?
  - [ ] Is variable/method/class name meaningful? (as it is a short comment)
  - [ ] Are the names following [pep8](https://realpython.com/python-pep8/#naming-conventions)?
- [ ] Is coverage rate high enough? (if there is unittest)

## Requested deadline for review
Can you please review this PR by `2022/09/30` ?